### PR TITLE
fix: disable telescope extension in config

### DIFF
--- a/lua/denote/init.lua
+++ b/lua/denote/init.lua
@@ -13,7 +13,7 @@ function M.setup(options)
   if options.integrations.oil then
     require("denote.extensions.oil").setup(options)
   end
-  if options.integrations.telescope then
+  if options.integrations.telescope.enabled then
     require("denote.extensions.telescope").setup(options)
   end
 


### PR DESCRIPTION
When checking if telescope extension is enable we need to check inside the table at the enable value.