### PR TITLE
Fix Telescope insert_link crash when relpath returns nil

### DIFF
--- a/lua/telescope/_extensions/denote.lua
+++ b/lua/telescope/_extensions/denote.lua
@@ -202,7 +202,7 @@ return require("telescope").register_extension({
               local links = {}
 
               for _, entry in ipairs(entries) do
-                local path = get_relative_path(entry.path)
+                local path = get_relative_path(entry.path) or entry.path
                 local description
 
                 if not is_multiple then


### PR DESCRIPTION
get_relative_path() can return nil when linking from buffers outside the Denote directory. Fallback to full path to avoid crash