### PR TITLE
Update default filetype configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example config via [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 --@type Denote.Configuration
 vim.g.denote = {
-  filetype = "md",
+  filetype = "markdown-toml",
   directory = "~/notes/",
   prompts = { "title", "keywords" },
   integrations = {

--- a/lua/denote/config.lua
+++ b/lua/denote/config.lua
@@ -18,7 +18,7 @@
 
 --@type Denote.Configuration
 local defaults = {
-  filetype = "md",
+  filetype = "markdown-toml",
   directory = "~/notes/",
   prompts = { "title", "keywords" }, -- "date", "title", "keywords", "signature", "extension"
   integrations = {


### PR DESCRIPTION
The configuration in the README was not up to date and would crash. This fixes it.