### PR TITLE
ftdetect + orgmode integration improvements

### DIFF
--- a/docs/denote.txt
+++ b/docs/denote.txt
@@ -67,16 +67,192 @@ Tasks, and Engagements.
 ==============================================================================
 2. Setup                                                        *denote-setup*
 
-TODO
+To use `denote.nvim`, configure it with your preferred options. The plugin
+provides sensible defaults but can be customized to fit your workflow.
 
+CONFIGURATION                                               *denote-setup-config*
+
+The following options are available: >lua
+    vim.g.denote = {
+      filetype = "markdown-toml",           -- File type for new notes
+      directory = "~/notes/",               -- Directory for Denote files
+      prompts = { "title", "keywords" },    -- Fields to prompt during creation
+      integrations = {                      -- Integrations, refer to |denote-integrations|
+        oil = false,
+        telescope = false,
+      },
+    }
+<
+
+OPTIONS                                                   *denote-setup-options*
+
+{filetype}
+    Default file type for new notes. Available options are:
+    - "markdown-toml" (default) - Markdown with TOML frontmatter
+    - "markdown-yaml" - Markdown with YAML frontmatter
+    - "org" - Org-mode format
+    - "neorg" - Neorg format
+    - "text" - Plain text
+
+{directory}
+    Path to the directory where Denote files are stored. Defaults to "~/notes/".
+    The trailing "/" is added automatically if not provided.
+
+{prompts}
+    Array of field names to prompt the user for during note creation and
+    renaming. Available fields are: "date", "title", "keywords", "signature",
+    and "extension". Defaults to { "title", "keywords" }.
+
+{integrations}
+    Table of integrations with other plugins. Refer to |denote-integrations| for
+    details.
 
 ==============================================================================
 3. API                                                            *denote-api*
 
-TODO
+The denote.nvim plugin provides a set of commands and Lua functions for
+managing Denote files. All core functionality can be accessed through both
+user commands and direct Lua function calls.
+
+                                                              *denote-api-core*
+3.1 Create a new note ~
+
+Create a new note interactively. The user is prompted for fields defined in
+the configuration's `prompts` option.
+
+Command: >vim
+    :Denote
+<
+
+Lua function: >lua
+    require("denote.api").denote()
+<
+
+Returns: boolean indicating success.
+
+                                                         *denote-api-rename-file*
+3.2 Rename file to Denote format ~
+
+Rename an existing file to comply with the Denote naming scheme. If no
+arguments are provided, prompts the user for each field in the configuration's
+`prompts` option. Defaults to the current file if `filename` is not provided.
+
+Command: >vim
+    :Denote rename-file
+<
+
+Lua function: >lua
+    require("denote.api").rename_file(filename?)
+<
+
+Parameters:
+    {filename?} (string) - File path to rename. If not provided, uses the
+                         current buffer's file.
+
+Returns: boolean indicating success.
+
+                                                     *denote-api-rename-title*
+3.3 Rename file title ~
+
+Update only the title component of a file. If `title` is not provided, the
+user is prompted for it. Defaults to the current file if `filename` is not
+provided.
+
+Command: >vim
+    :Denote rename-file-title
+<
+
+Lua function: >lua
+    require("denote.api").rename_file_title(filename?, title?)
+<
+
+Parameters:
+    {filename?} (string) - File path to rename. If not provided, uses the
+                           current buffer's file.
+    {title?} (string)    - New title for the file. If not provided, the user is
+                           prompted for it.
+
+Returns: boolean indicating success.
+
+                                                  *denote-api-rename-keywords*
+3.4 Rename file keywords ~
+
+Update only the keywords component of a file. If `keywords` is not provided,
+the user is prompted for it. Defaults to the current file if `filename` is not
+provided.
+
+Command: >vim
+    :Denote rename-file-keywords
+<
+
+Lua function: >lua
+    require("denote.api").rename_file_keywords(filename?, keywords?)
+<
+
+Parameters:
+    {filename?} (string) - File path to rename. If not provided, uses the
+                           current buffer's file.
+    {keywords?} (string) - New keywords for the file. If not provided, the
+                           user is prompted for it.
+
+Returns: boolean indicating success.
+
+                                                 *denote-api-rename-signature*
+3.5 Rename file signature ~
+
+Update only the signature component of a file. If `signature` is not provided,
+the user is prompted for it. Defaults to the current file if `filename` is not
+provided.
+
+Command: >vim
+    :Denote rename-file-signature
+<
+
+Lua function: >lua
+    require("denote.api").rename_file_signature(filename?, signature?)
+<
+
+Parameters:
+    {filename?} (string)  - File path to rename. If not provided, uses the
+                            current buffer's file.
+    {signature?} (string) - New signature for the file. If not provided, the
+                            user is prompted for it.
+
+Returns: boolean indicating success.
+
+                                                           *denote-api-backlinks*
+3.6 Show backlinks ~
+
+Populate the location list with all files that link to the current note.
+Opens the location list window to display the results.
+
+Command: >vim
+    :Denote backlinks
+<
+
+Lua function: >lua
+    require("denote.api").backlinks()
+<
+
+Returns: nil
 
 ==============================================================================
 4. Integrations                                          *denote-integrations*
+
+denote.nvim ships with a couple of integrations with other plugins to enhance
+the user experience and provide additional functionality. These integrations
+are optional and can be enabled or disabled through the `integrations` option
+in the configuration. In the configuration table, the `integrations` field is
+a table that can contain the following keys:
+
+{integrations.oil}
+    Enable syntax highlighting for Denote files in Oil.nvim file browser.
+    Requires Oil.nvim to be installed. Defaults to false.
+
+{integrations.telescope}
+    Enable Telescope pickers for searching and linking notes. Can be a boolean
+    or a table with `enabled` and `opts` keys for customization. Requires
+    Telescope to be installed. Defaults to false.
 
                                                                   *denote-oil*
 4.1 stevearc/oil.nvim ~
@@ -86,6 +262,8 @@ buffers by implementing custom syntax highlighting for the various components
 of the Denote file naming convention. It aims to improve the visual clarity
 and user experience when navigating and managing Denote files through the Oil
 file explorer interface.
+
+SETUP                                                     *denote-oil-setup*
 
 To enable, add to your `denote.nvim` configuration the following: >lua
     opts = {
@@ -108,7 +286,7 @@ To overwrite or clear this groups, refer to |highlight|.
 -----------------------------------------------------------------------------
 
                                                            *denote-telescope*
-4.1 nvim-telescope/telescope.nvim ~
+4.2 nvim-telescope/telescope.nvim ~
 
 This module provides a Telescope integration for the Denote plugin, allowing
 users to search and navigate Denote files using Telescope's interface.
@@ -184,7 +362,7 @@ As a fallback, the Telescope picker will display just the filename in the case
 the file is non-compliant with the standard Denote format.
 
 Each component is highlighted differently for easy recognition. The default
-highlight groups are defined as follows: 
+highlight groups are defined as follows:
 >vim
     hi def link DenoteDate      Number
     hi def link DenoteSignature Special

--- a/docs/denote.txt
+++ b/docs/denote.txt
@@ -199,8 +199,79 @@ REQUIREMENTS                                    *denote-telescope-requirements*
 This integrations requires the Telescope plugin to be installed and available.
 If Telescope is not found, an error will be raised.
 
+-----------------------------------------------------------------------------
+
+                                                              *denote-orgmode*
+4.3 nvim-orgmode/orgmode ~
+
+This integration enables custom `[[denote:...]]` link format within org-mode
+files. It provides a seamless way to link between Denote notes using Org-mode's
+native link syntax, with smart file handling and link completion.
+
+SETUP                                                   *denote-orgmode-setup*
+
+To enable this integration, add the following to your `orgmode` configuration:
+>lua
+    require("orgmode").setup({
+      -- your other config...
+      hyperlinks = {
+        sources = {
+          require("denote.extensions.orgmode"):new({
+            files = vim.g.denote.directory
+          }),
+        },
+      },
+    })
+<
+
+LINK FORMAT                                             *denote-orgmode-format*
+
+The Denote link format in org-mode is: >vim
+    [[denote:IDENTIFIER][description]]
+<
+
+Where `IDENTIFIER` is the timestamp of the Denote file (e.g. `20240601T174946`).
+For example: >text
+    [[denote:20240601T174946][How to Tie a Tie]]
+<
+
+When you follow this link (using `C-c C-o` in org-mode), the plugin will open
+the corresponding Denote file.
+
+FEATURES                                                 *denote-orgmode-features*
+
+Smart File Opening ~
+    The plugin intelligently handles different file types:
+    - Supported denote file types (.md, .org, .txt, .norg) are opened in
+      Neovim
+    - Other file types following the denote convention are opened with the
+      system's default application
+
+Link Autocomplete ~
+    When typing a Denote link, the plugin provides autocomplete suggestions
+    for available Denote file identifiers based on files in your Denote
+    directory.
+
+CONFIGURATION                                         *denote-orgmode-configuration*
+
+{files}
+    (required) Path to the Denote files directory. This is typically set to
+    `vim.g.denote.directory`.
+
+{config}
+    (optional) Advanced configuration table for customizing link patterns.
+    Supports the following fields:
+    - `denote_directory` (string) - Custom denote directory path (overrides
+      the `files` parameter if provided).
+
+REQUIREMENTS                                         *denote-orgmode-requirements*
+
+This integration requires the nvim-orgmode plugin to be installed and
+available. If orgmode is not found, an error will be raised. For installation
+instructions, visit: https://github.com/nvim-orgmode/orgmode
+
 ==============================================================================
-                                                                   *changelog*
+                                                                    *changelog*
 
 TODO
 

--- a/ftdetect/denote.lua
+++ b/ftdetect/denote.lua
@@ -1,0 +1,44 @@
+---@module "after.ftdetect.denote"
+---@author Carlos Vigil-Vásquez
+---@license MIT 2026
+
+--- Set current filetype as a denote note if (i) complies with naming convention or
+--- (ii) is located inside the denote directory and complies with the naming convention.
+local function set_as_denote()
+    if vim.bo.filetype ~= "" then
+        vim.bo.filetype = vim.bo.filetype .. ".denote"
+    else
+        vim.bo.filetype = "denote"
+    end
+end
+
+--- Check if file hash denote ID in file name
+---@param filepath string
+---@return boolean
+local function is_denote(filepath)
+    local filename = vim.fs.basename(filepath)
+    return filename:match("^%d%d%d%d%d%d%d%dT%d%d%d%d%d%d") ~= nil
+end
+
+--- Check if file is located inside a denote silo
+---@param filepath string
+---@return boolean
+local function in_silo(filepath)
+    return filepath:match(vim.fs.normalize(vim.g.denote.directory)) ~= nil
+end
+
+vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
+    pattern = "*",
+    group = vim.api.nvim_create_augroup("denote", { clear = true }),
+    desc = "Detect if a file is a denote note and set the filetype accordingly",
+    callback = function(ev)
+        local logger = require("denote.core.logger")
+        local filepath = vim.fs.abspath(ev.file)
+        if (in_silo(filepath) and is_denote(filepath)) or (is_denote(filepath)) then
+            set_as_denote()
+            logger.debug("Set filetype to " .. vim.bo.filetype .. " for " .. ev.file)
+            require("denote.ui.highlights").setup()
+            logger.debug("Set up highlights for " .. ev.file)
+        end
+    end,
+})

--- a/lua/denote/autocmd.lua
+++ b/lua/denote/autocmd.lua
@@ -7,21 +7,7 @@ local logger = require("denote.core.logger")
 local M = {}
 
 M.setup = function()
-  local augroup = vim.api.nvim_create_augroup("denote", { clear = true })
-
-  -- Set denote filetype
-  vim.api.nvim_create_autocmd({ "BufReadPre", "BufNewFile" }, {
-    pattern = vim.g.denote.directory .. "*",
-    group = augroup,
-    desc = "Set Denote filetype",
-    callback = function(args)
-      local current_ft = vim.bo[args.buf].filetype
-      if not vim.endswith(current_ft, ".denote") then
-        logger.info("Setting buffer " .. args.buf .. " filetype to " .. current_ft .. ".denote")
-        vim.bo[args.buf].filetype = current_ft .. ".denote"
-      end
-    end,
-  })
+  local augroup = vim.api.nvim_create_augroup("denote", { clear = false })
 
   -- Populate links cache
   vim.api.nvim_create_autocmd("BufReadPost", {

--- a/lua/denote/extensions/orgmode.lua
+++ b/lua/denote/extensions/orgmode.lua
@@ -1,6 +1,20 @@
 local CONFIG = vim.g.denote
 local Naming = require("denote.naming")
 
+
+local function open(filepath)
+  local open_cmd
+  if vim.fn.has 'win32' == 1 then
+    open_cmd = 'start'
+  elseif vim.fn.has 'macunix' == 1 then
+    open_cmd = 'open'
+  else -- Assume Unix
+    open_cmd = 'xdg-open'
+  end
+  vim.notify('[dneote] Opening URL with: ' .. open_cmd .. ' ' .. vim.fn.shellescape(filepath), vim.log.levels.INFO)
+  vim.fn.jobstart({ open_cmd, filepath }, { detach = true })
+end
+
 ---@class OrgLinkDenote:OrgLinkType
 ---@field private files OrgFiles
 ---@field private config table Configuration for denote integration
@@ -29,8 +43,12 @@ function OrgLinkDenote:follow(link)
     local identifier = tostring(self:_parse(link))
     local denote_file = self:_find_denote_file(identifier)
     if denote_file ~= nil then
-      vim.cmd("edit " .. vim.fn.fnameescape(denote_file))
-      return true
+      if vim.tbl_contains({"md", "org", "txt", "norg"}, vim.fn.fnamemodify(denote_file, ":e")) then
+        vim.cmd("edit " .. vim.fn.fnameescape(denote_file))
+        return true
+      else
+        open(denote_file)
+      end
     end
   end
   return false

--- a/plugin/denote.lua
+++ b/plugin/denote.lua
@@ -2,7 +2,6 @@
 ---@author Carlos Vigil-Vásquez
 ---@license MIT 2025
 
--- Create autocommand to
 if not vim.g.loaded_denote_plugin then
   local logger = require("denote.core.logger")
   logger.info("Setting up plugin")
@@ -18,5 +17,4 @@ if not vim.g.loaded_denote_plugin then
   require("denote.autocmd").setup()
 end
 
-vim.g.loaded_denote_plugin = false
-
+vim.g.loaded_denote_plugin = true


### PR DESCRIPTION
- **fix: set `vim.g.loaded_denote_plugin` to true after plugin setup**
- **feat(ft): move to ftdetect**
- **feat(orgmode): open non-text denote links in system app**
- **docs: write orgmode integration section**

Closes #6 